### PR TITLE
Fix date type bug

### DIFF
--- a/packages/custom/recruits/public/controllers/recruits.form.js
+++ b/packages/custom/recruits/public/controllers/recruits.form.js
@@ -70,6 +70,10 @@ function RecruitsFormController(
     {
         if ($scope.isEdit) {
             Recruits.get({recruitId:$scope.id}, function(recruit){
+                if (angular.isDefined(recruit.birthDate)) {
+                    //fixes a type bug caused by loading a date string into the widget
+                    recruit.birthDate = new Date(recruit.birthDate);
+                }
                 $scope.recruit = recruit;
             });
         }


### PR DESCRIPTION
Loading a string into the ui-date component causes a type error.  When
loading it, convert the string to a date object.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/tjboudreaux/recruittracker/2)

<!-- Reviewable:end -->
